### PR TITLE
스프링 테스트 컨텍스트를 적용하라

### DIFF
--- a/toby-study/build.gradle
+++ b/toby-study/build.gradle
@@ -16,12 +16,14 @@ dependencies {
 
     implementation group: 'net.sourceforge.cglib', name: 'com.springsource.net.sf.cglib', version: '2.2.0'
     implementation group: 'commons-logging', name: 'commons-logging', version: '1.1.1'
-    implementation group: 'org.springframework', name: 'spring-asm', version: '3.0.7.RELEASE'
-    implementation group: 'org.springframework', name: 'spring-beans', version: '3.0.7.RELEASE'
-    implementation group: 'org.springframework', name: 'spring-context', version: '3.0.7.RELEASE'
-    implementation group: 'org.springframework', name: 'spring-core', version: '3.0.7.RELEASE'
-    implementation group: 'org.springframework', name: 'spring-expression', version: '3.0.7.RELEASE'
-    implementation group: 'org.springframework', name: 'spring-jdbc', version: '3.0.7.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-asm', version: '3.1.4.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-beans', version: '3.1.4.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-context', version: '3.1.4.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-core', version: '3.1.4.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-expression', version: '3.1.4.RELEASE'
+    implementation group: 'org.springframework', name: 'spring-jdbc', version: '3.1.4.RELEASE'
+
+    testImplementation group: 'org.springframework', name: 'spring-test', version: '3.1.4.RELEASE'
 
     testCompileOnly group: 'junit', name: 'junit', version: '4.12'
     testCompileOnly group: 'org.assertj', name: 'assertj-core', version: '3.18.0'

--- a/toby-study/src/test/java/springbook/user/dao/UserDaoTest.java
+++ b/toby-study/src/test/java/springbook/user/dao/UserDaoTest.java
@@ -6,13 +6,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.sql.SQLException;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import springbook.user.domain.User;
 
+@RunWith(SpringJUnit4ClassRunner.class) // 스프링의 테스트 컨텍스트 프레임워크의 JUnit확장기능 지정
+@ContextConfiguration(classes = {DaoFactory.class})
 public class UserDaoTest {
 
+  @Autowired
+  private ApplicationContext context;
   private UserDao dao;  //setUp() 메소드에서 만드는 오브젝트를 테스트 메소드에서 사용할 수 있도록 인스턴스 변수로 선언한다.
   private User user1;
   private User user2;
@@ -20,7 +27,6 @@ public class UserDaoTest {
 
   @Before // JUnit이 제공하는 애노테이션. @Test  메소드가 실행되기 전에 먼저 실행해야하는 메소드를 정의한다.
   public void setUp() {
-    ApplicationContext context = new AnnotationConfigApplicationContext(DaoFactory.class);
     this.dao = context.getBean("userDao", UserDao.class);
 
     this.user1 = new User("hello0", "world0", "hello world0");


### PR DESCRIPTION
- 스프링 연관 라이브러리 버전 3.0.7 -> 3.1.4 로 버전 업
- 스프링 테스트 컨텍스트를 이용하도록 변경